### PR TITLE
Moved helper functions from FormRow to separate file in order to solve problems where FormRows could not be overriden

### DIFF
--- a/src/FormRowHelpers.js
+++ b/src/FormRowHelpers.js
@@ -2,7 +2,7 @@
 
 import { Component } from 'inferno'
 
-import { renderString } from './common'
+import { renderString } from './widgets/common'
 import { i18n } from 'isomorphic-schema'
 
 import _bs_Label from 'inferno-bootstrap/lib/Form/Label'

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ import { FileUploadWidget, ProgressOverlay } from './widgets/FileUploadWidget/in
 
 import CustomWidget from './CustomWidget'
 
-import { CheckboxRow, ObjectRow, Row, ErrorMsg, HelpMsg, Label, unpackInvariantErrors } from './widgets/FormRow'
+import { CheckboxRow, ObjectRow, Row } from './widgets/FormRow'
+import { ErrorMsg, HelpMsg, Label, unpackInvariantErrors } from './widgets/validation'
 import { renderString } from './widgets/common'
 import { getElOffset, escapeIdSelector, generateId, throttle } from './widgets/utils'
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import { FileUploadWidget, ProgressOverlay } from './widgets/FileUploadWidget/in
 import CustomWidget from './CustomWidget'
 
 import { CheckboxRow, ObjectRow, Row } from './widgets/FormRow'
-import { ErrorMsg, HelpMsg, Label, unpackInvariantErrors } from './widgets/validation'
+import { ErrorMsg, HelpMsg, Label, unpackInvariantErrors } from './FormRowHelpers'
 import { renderString } from './widgets/common'
 import { getElOffset, escapeIdSelector, generateId, throttle } from './widgets/utils'
 

--- a/src/widgets/FormRow.js
+++ b/src/widgets/FormRow.js
@@ -22,7 +22,7 @@ import {
     Label as _bs_Label
  } from 'inferno-bootstrap'
 
-import { ErrorMsg, HelpMsg, unpackInvariantErrors, Label} from './validation'
+import { ErrorMsg, HelpMsg, unpackInvariantErrors, Label} from '../FormRowHelpers'
 
 /*
     PROPS:

--- a/src/widgets/FormRow.js
+++ b/src/widgets/FormRow.js
@@ -22,63 +22,7 @@ import {
     Label as _bs_Label
  } from 'inferno-bootstrap'
 
-function Label (props) {
-    return <_bs_Label>{renderString(props.children, props.options && props.options.lang)}</_bs_Label>
-}
-
-function HelpMsg (props, context) {
-    // don't render if nothing to show
-    if (!props.text && !props.required) return null
-
-    const outp = []
-    if (props.text) outp.push(renderString(props.text, props.options && props.options.lang))
-    if (props.required) outp.push(renderString(i18n('isomorphic-schema--field_required', '(required)'), props.options && props.options.lang, '(required)'))
-
-    if (context && context.renderHelpAsHtml) {
-        return <FormText className="text-muted" for={props.id} dangerouslySetInnerHTML={{ __html: outp.join(' ')}} />
-    } else {
-        return <FormText className="text-muted" for={props.id}>{outp.join(' ')}</FormText>
-    }
-}
-
-class ErrorMsg extends Component {
-
-    componentDidMount () {
-        animateOnAdd(findDOMNode(this), 'InfernoFormlib-ErrorMsg--Animation')
-    }
-
-    componentWillUnmount () {
-        animateOnRemove(findDOMNode(this), 'InfernoFormlib-ErrorMsg--Animation')
-    }
-
-    render () {
-        return <FormFeedback>{renderString(this.props.validationError.i18nLabel, this.props.options && this.props.options.lang, this.props.validationError.message)}</FormFeedback>
-    }
-}
-
-function unpackInvariantErrors (validationError, namespace) {
-    if (validationError === undefined) return
-
-    let invariantError
-    if (Array.isArray(validationError.invariantErrors)){
-        
-        const dotName = namespace.join('.')
-        let tmpInvErrs = validationError.invariantErrors.filter((invErr) => {
-            // Pattern match field name of error with current namespace to see if it is a match
-            return invErr.fields.reduce((prev, curr) => prev || (curr === dotName), false)
-        })
-        
-        if (tmpInvErrs.length > 1) {
-            invariantError = {
-                message: 'There are several form value errors here',
-                i18nLabel: 'inferno-formlib--multiple_invariant_errors'
-            }
-        } else {
-            invariantError = tmpInvErrs[0]
-        }
-    }
-    return invariantError
-}
+import { ErrorMsg, HelpMsg, unpackInvariantErrors, Label} from './validation'
 
 /*
     PROPS:

--- a/src/widgets/validation.js
+++ b/src/widgets/validation.js
@@ -1,0 +1,77 @@
+'use strict'
+
+import { Component } from 'inferno'
+
+import { renderString } from './common'
+import { i18n } from 'isomorphic-schema'
+
+import _bs_Label from 'inferno-bootstrap/lib/Form/Label'
+import FormText from 'inferno-bootstrap/lib/Form/FormText'
+import FormFeedback from 'inferno-bootstrap/lib/Form/FormFeedback'
+
+
+/*
+
+    Components and helper functions for sending feedback to user about validation errors.
+
+*/
+
+function Label (props) {
+  return <_bs_Label>{renderString(props.children, props.options && props.options.lang)}</_bs_Label>
+}
+
+function HelpMsg (props, context) {
+  // don't render if nothing to show
+  if (!props.text && !props.required) return null
+
+  const outp = []
+  if (props.text) outp.push(renderString(props.text, props.options && props.options.lang))
+  if (props.required) outp.push(renderString(i18n('isomorphic-schema--field_required', '(required)'), props.options && props.options.lang, '(required)'))
+
+  if (context && context.renderHelpAsHtml) {
+      return <FormText className="text-muted" for={props.id} dangerouslySetInnerHTML={{ __html: outp.join(' ')}} />
+  } else {
+      return <FormText className="text-muted" for={props.id}>{outp.join(' ')}</FormText>
+  }
+}
+
+function unpackInvariantErrors (validationError, namespace) {
+  if (validationError === undefined) return
+
+  let invariantError
+  if (Array.isArray(validationError.invariantErrors)){
+      
+      const dotName = namespace.join('.')
+      let tmpInvErrs = validationError.invariantErrors.filter((invErr) => {
+          // Pattern match field name of error with current namespace to see if it is a match
+          return invErr.fields.reduce((prev, curr) => prev || (curr === dotName), false)
+      })
+      
+      if (tmpInvErrs.length > 1) {
+          invariantError = {
+              message: 'There are several form value errors here',
+              i18nLabel: 'inferno-formlib--multiple_invariant_errors'
+          }
+      } else {
+          invariantError = tmpInvErrs[0]
+      }
+  }
+  return invariantError
+}
+
+class ErrorMsg extends Component {
+
+    componentDidMount () {
+        animateOnAdd(this.$LI.dom, 'InfernoFormlib-ErrorMsg--Animation')
+    }
+  
+    componentWillUnmount () {
+        animateOnRemove(this.$LI.dom, 'InfernoFormlib-ErrorMsg--Animation')
+    }
+  
+    render () {
+        return <FormFeedback>{renderString(this.props.validationError.i18nLabel, this.props.options && this.props.options.lang, this.props.validationError.message)}</FormFeedback>
+    }
+  }
+
+export { Label, ErrorMsg, HelpMsg, unpackInvariantErrors }


### PR DESCRIPTION
Since the Adapter was created in the same file as some helper functions one could not override the Adapter and in the same time use the helper functions.

This is solved by moving some of the functions to a separate file.